### PR TITLE
Update for 1.20.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.22
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.4
+loader_version=0.14.24
 # Mod Properties
 mod_version=1.0-SNAPSHOT
 maven_group=dev.u9g
 archives_base_name=minecraft-data-generator-server
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.87.0+1.20.1
+fabric_version=0.90.4+1.20.2

--- a/src/main/java/dev/u9g/minecraftdatagenerator/generators/RecipeDataGenerator.java
+++ b/src/main/java/dev/u9g/minecraftdatagenerator/generators/RecipeDataGenerator.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.item.Item;
+import net.minecraft.item.Items;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeEntry;
@@ -52,20 +53,17 @@ public class RecipeDataGenerator implements IDataGenerator {
                         ingr.add(getRawIdFor(matching[0].getItem()));
                     }
                 }
-                Lists.reverse(ingr);
+                //Lists.reverse(ingr);
 
                 JsonArray inShape = new JsonArray();
 
+
                 var iter = ingr.iterator();
-                for (int y = 0; y < 3; y++) {
+                for (int y = 0; y < sr.getHeight(); y++) {
                     var jsonRow = new JsonArray();
-                    int one = iter.next();
-                    int two = iter.next();
-                    int three = iter.next();
-                    if (y > 0 && one == -1 && two == -1 && three == -1) continue;
-                    jsonRow.add(one);
-                    jsonRow.add(two);
-                    jsonRow.add(three);
+                    for (int z = 0; z < sr.getWidth();z++) {
+                        jsonRow.add(iter.next());
+                    }
                     inShape.add(jsonRow);
                 }
 

--- a/src/main/java/dev/u9g/minecraftdatagenerator/generators/RecipeDataGenerator.java
+++ b/src/main/java/dev/u9g/minecraftdatagenerator/generators/RecipeDataGenerator.java
@@ -10,6 +10,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.item.Item;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.recipe.ShapedRecipe;
 import net.minecraft.recipe.ShapelessRecipe;
 import net.minecraft.registry.DynamicRegistryManager;
@@ -26,12 +27,15 @@ public class RecipeDataGenerator implements IDataGenerator {
         return "recipes";
     }
 
+
+
     @Override
     public JsonElement generateDataJson() {
         DynamicRegistryManager registryManager = DGU.getWorld().getRegistryManager();
         JsonObject finalObj = new JsonObject();
         Multimap<Integer, JsonObject> recipes = ArrayListMultimap.create();
-        for (Recipe<?> recipe : Objects.requireNonNull(DGU.getWorld()).getRecipeManager().values()) {
+        for (RecipeEntry<?> recipeE : Objects.requireNonNull(DGU.getWorld()).getRecipeManager().values()) {
+            Recipe<?> recipe = recipeE.value();
             if (recipe instanceof ShapedRecipe sr) {
                 var ingredients = sr.getIngredients();
                 List<Integer> ingr = new ArrayList<>();
@@ -69,11 +73,11 @@ public class RecipeDataGenerator implements IDataGenerator {
                 finalRecipe.add("inShape", inShape);
 
                 var resultObject = new JsonObject();
-                resultObject.addProperty("id", getRawIdFor(sr.getOutput(registryManager).getItem()));
-                resultObject.addProperty("count", sr.getOutput(registryManager).getCount());
+                resultObject.addProperty("id", getRawIdFor(sr.getResult(registryManager).getItem()));
+                resultObject.addProperty("count", sr.getResult(registryManager).getCount());
                 finalRecipe.add("result", resultObject);
 
-                String id = ((Integer) getRawIdFor(sr.getOutput(registryManager).getItem())).toString();
+                String id = ((Integer) getRawIdFor(sr.getResult(registryManager).getItem())).toString();
 
                 if (!finalObj.has(id)) {
                     finalObj.add(id, new JsonArray());
@@ -113,10 +117,10 @@ public class RecipeDataGenerator implements IDataGenerator {
                 var rootRecipeObject = new JsonObject();
                 rootRecipeObject.add("ingredients", ingredients);
                 var resultObject = new JsonObject();
-                resultObject.addProperty("id", getRawIdFor(sl.getOutput(registryManager).getItem()));
-                resultObject.addProperty("count", sl.getOutput(registryManager).getCount());
+                resultObject.addProperty("id", getRawIdFor(sl.getResult(registryManager).getItem()));
+                resultObject.addProperty("count", sl.getResult(registryManager).getCount());
                 rootRecipeObject.add("result", resultObject);
-                recipes.put(getRawIdFor(sl.getOutput(registryManager).getItem()), rootRecipeObject);
+                recipes.put(getRawIdFor(sl.getResult(registryManager).getItem()), rootRecipeObject);
             }
         }
         recipes.forEach((a, b) -> {


### PR DESCRIPTION
Fixes the Recipe Generator to allow it to compile under 1.20.2 even thought it is currently not used in minecraft-data-generator-server and updates the gradle.properties files for 1.20.2