### PR TITLE
Add sound id to name mappings as generator for 1.9 thru 1.20

### DIFF
--- a/1.10.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.10.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -35,6 +35,7 @@ public class DataGenerators {
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
         register(new AttributesDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.10.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.10.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,30 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.client.sound.SoundEvent;
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", SoundEvent.REGISTRY.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        SoundEvent.REGISTRY.forEach(sound -> resultsArray.add(generateSound(sound)));
+        return resultsArray;
+    }
+}

--- a/1.11.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.11.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -35,6 +35,7 @@ public class DataGenerators {
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
         register(new AttributesDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.11.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.11.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,30 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.client.sound.SoundEvent;
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", SoundEvent.REGISTRY.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        SoundEvent.REGISTRY.forEach(sound -> resultsArray.add(generateSound(sound)));
+        return resultsArray;
+    }
+}

--- a/1.12.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.12.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -35,6 +35,7 @@ public class DataGenerators {
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
         register(new AttributesDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.12.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.12.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,31 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.client.sound.SoundEvent;
+
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", SoundEvent.REGISTRY.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        SoundEvent.REGISTRY.forEach(sound -> resultsArray.add(generateSound(sound)));
+        return resultsArray;
+    }
+}

--- a/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -34,6 +34,7 @@ public class DataGenerators {
 //        register(new RecipeDataGenerator()); - On hold until mcdata supports multiple materials for a recipe
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,32 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.registry.Registry;
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(Registry<SoundEvent> registry, SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", registry.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        Registry<SoundEvent> soundEventRegistry = Registry.SOUND_EVENT;
+        soundEventRegistry.forEach(sound -> resultsArray.add(generateSound(soundEventRegistry, sound)));
+        return resultsArray;
+    }
+}

--- a/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -34,6 +34,7 @@ public class DataGenerators {
 //        register(new RecipeDataGenerator()); - On hold until mcdata supports multiple materials for a recipe
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,32 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.registry.Registry;
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(Registry<SoundEvent> registry, SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", registry.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        Registry<SoundEvent> soundEventRegistry = Registry.SOUND_EVENT;
+        soundEventRegistry.forEach(sound -> resultsArray.add(generateSound(soundEventRegistry, sound)));
+        return resultsArray;
+    }
+}

--- a/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -34,6 +34,7 @@ public class DataGenerators {
 //        register(new RecipeDataGenerator()); - On hold until mcdata supports multiple materials for a recipe
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,33 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import dev.u9g.minecraftdatagenerator.util.DGU;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.sound.SoundEvent;
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(Registry<SoundEvent> registry, SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", registry.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        Registry<SoundEvent> soundEventRegistry = DGU.getWorld().getRegistryManager().get(RegistryKeys.SOUND_EVENT);
+        soundEventRegistry.forEach(sound -> resultsArray.add(generateSound(soundEventRegistry, sound)));
+        return resultsArray;
+    }
+}

--- a/1.9.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/1.9.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -35,6 +35,7 @@ public class DataGenerators {
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
         register(new AttributesDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/1.9.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/1.9.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,30 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.client.sound.SoundEvent;
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", SoundEvent.REGISTRY.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        SoundEvent.REGISTRY.forEach(sound -> resultsArray.add(generateSound(sound)));
+        return resultsArray;
+    }
+}

--- a/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
+++ b/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/DataGenerators.java
@@ -34,6 +34,7 @@ public class DataGenerators {
 //        register(new RecipeDataGenerator()); - On hold until mcdata supports multiple materials for a recipe
         register(new LanguageDataGenerator());
         register(new InstrumentsDataGenerator());
+        register(new SoundsDataGenerator());
     }
 
     public static void register(IDataGenerator generator) {

--- a/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -1,0 +1,32 @@
+package dev.u9g.minecraftdatagenerator.generators;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.registry.Registry;
+
+
+public class SoundsDataGenerator implements IDataGenerator {
+
+    public static JsonObject generateSound(Registry<SoundEvent> registry, SoundEvent soundEvent) {
+        JsonObject soundDesc = new JsonObject();
+
+        soundDesc.addProperty("id", registry.getRawId(soundEvent));
+        soundDesc.addProperty("name", soundEvent.getId().getPath());
+
+        return soundDesc;
+    }
+
+    @Override
+    public String getDataName() {
+        return "sounds";
+    }
+
+    @Override
+    public JsonArray generateDataJson() {
+        JsonArray resultsArray = new JsonArray();
+        Registry<SoundEvent> soundEventRegistry = Registry.SOUND_EVENT;
+        soundEventRegistry.forEach(sound -> resultsArray.add(generateSound(soundEventRegistry, sound)));
+        return resultsArray;
+    }
+}


### PR DESCRIPTION
This adds a sounds.json file that hold mappings for the numeral ID to string id for sounds. 