### PR TITLE
1.20.5-1.21 - Prioritize mineable material when multiple matches are found to fix problem of wrong dig time computation

### DIFF
--- a/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {

--- a/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -115,7 +115,11 @@ public class BlocksDataGenerator implements IDataGenerator {
         if (matchingMaterials.isEmpty()) {
             return "default";
         }
-        return matchingMaterials.getFirst().getMaterialName();
+        return matchingMaterials.stream()
+            .filter(m -> m.getMaterialName().startsWith("mineable/"))
+            .findFirst()
+            .map(MaterialsDataGenerator.MaterialInfo::getMaterialName)
+            .orElseGet(() -> matchingMaterials.getFirst().getMaterialName());
     }
 
     public static JsonObject generateBlock(List<MaterialsDataGenerator.MaterialInfo> materials, Block block) {


### PR DESCRIPTION
Fix implemented and tested only on 1.21.11. Looks like digTime became right. Please tell me if something wrong with this implementation and i don't see it.