### PR TITLE
Fix food saturation for 1.21.5 - 1.21.11

### DIFF
--- a/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);

--- a/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);

--- a/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);

--- a/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);

--- a/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);

--- a/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);

--- a/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
+++ b/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/FoodsDataGenerator.java
@@ -26,7 +26,7 @@ public class FoodsDataGenerator implements IDataGenerator {
         FoodProperties foodComponent = Objects.requireNonNull(foodItem.components().get(DataComponents.FOOD));
         float foodPoints = foodComponent.nutrition();
         float saturationRatio = foodComponent.saturation() * 2.0F;
-        float saturation = foodPoints * saturationRatio;
+        float saturation = foodComponent.saturation();
 
         foodDesc.addProperty("foodPoints", foodPoints);
         foodDesc.addProperty("saturation", saturation);


### PR DESCRIPTION
Food saturation values for versions 1.21.5 - 1.21.11 were nonsense, because in the code, saturation was defined with this code
```java
float saturation = foodPoints * saturationRatio;
```
but it should be
```java
float saturation = foodComponent.saturation();
```

This pull request should close issue https://github.com/PrismarineJS/minecraft-data/issues/1204