### PR TITLE
Fix double-applied +1 offset in sound IDs (SoundsDataGenerator)

### DIFF
--- a/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -9,7 +9,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", Registry.SOUND_EVENT.getRawId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", Registry.SOUND_EVENT.getRawId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.getId().getPath());
 
         return soundDesc;

--- a/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -9,7 +9,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", Registries.SOUND_EVENT.getRawId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", Registries.SOUND_EVENT.getRawId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.getId().getPath());
 
         return soundDesc;

--- a/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -9,7 +9,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", Registries.SOUND_EVENT.getRawId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", Registries.SOUND_EVENT.getRawId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.id().getPath());
 
         return soundDesc;

--- a/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -12,7 +12,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", BuiltInRegistries.SOUND_EVENT.getId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.location().getPath());
 
         return soundDesc;

--- a/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
+++ b/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/SoundsDataGenerator.java
@@ -9,7 +9,10 @@ public class SoundsDataGenerator implements IDataGenerator {
     public static JsonObject generateSound(SoundEvent soundEvent) {
         JsonObject soundDesc = new JsonObject();
 
-        soundDesc.addProperty("id", Registries.SOUND_EVENT.getRawId(soundEvent) + 1); // the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.
+        soundDesc.addProperty("id", Registries.SOUND_EVENT.getRawId(soundEvent)); // raw 0-indexed sound_event registry id. The wire packet encodes (id + 1),
+        // with 0 meaning "read an inline SoundEvent instead" — but that offset is applied by
+        // the packet codec (registryEntryHolder), NOT here. Adding it to the registry dump
+        // double-counts and shifts every consumer's sound lookup by one.
         soundDesc.addProperty("name", soundEvent.getId().getPath());
 
         return soundDesc;


### PR DESCRIPTION
## Problem

`SoundsDataGenerator` emits `registry.getId(sound) + 1` for 1.19.2+, with a comment:

> the plus 1 is required for 1.19.2+ due to Mojang using 0 in the packet to say that you should read a string id instead.

That protocol fact is real, but the offset is in the **wrong layer**. On the wire the `sound_effect` packet encodes the sound as an `IdOr<SoundEvent>` = `VarInt(rawId + 1)`, where `0` signals an inline `SoundEvent`. That `+1` belongs to the **packet codec**, not the registry dump.

Consumers already handle the wire offset. In `minecraft-protocol`, the `registryEntryHolder` type decodes it:

```js
const { value: n } = varint
if (n !== 0) return { value: { soundId: n - 1 } }   // subtracts 1 here
else /* read inline SoundEvent */
```

So baking +1 into sounds.json double-counts: the codec subtracts 1 to get the raw id, then the lookup hits a table shifted +1 — every sound resolves to the next entry in registry order. In practice entity.player.hurt reads as entity.player.death, entity.player.small_fall as entity.player.levelup, etc., surfacing to downstream users (mineflayer) as phantom events.

## Fix

Emit the raw 0-indexed registry id (drop the + 1) across all affected versions: 1.19.2, 1.20, 1.21, 1.21.3, 1.21.5, 1.21.6, 1.21.7, 1.21.8, 1.21.9, 1.21.10, 1.21.11. Versions ≤1.18, 1.19 and 1.20.4 were already correct.

## Verification

This change makes the generator emit exactly `registry.getId(sound)` - the raw `sound_event` registry id. I validated that value against the game's own authoritative registry: for each affected version I ran the vanilla server's built-in report generator (`java -jar server.jar --reports`), which dumps `minecraft:sound_event` with each entry's `protocol_id`, and compared it id-for-id against the corresponding 0-indexed `sounds.json`:

**11 versions, 17,944 sound ids, 0 mismatches** — `1.19.2, 1.20.1, 1.20.2, 1.21.1, 1.21.3, 1.21.4, 1.21.5, 1.21.6, 1.21.8, 1.21.9, 1.21.11`.

The name-set of each file was also cross-checked against the vanilla registry via [misode/mcmeta](https://github.com/misode/mcmeta).

