### PR TITLE
Fix water/lava diggable by detecting fluid blocks from code

### DIFF
--- a/mc/1.10.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.10.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -98,7 +98,7 @@ public class BlocksDataGenerator implements IDataGenerator {
 
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", ((BlockAccessor) block).getBlastResistance());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !defaultState.getMaterial().isFluid());
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registries.ITEMS.getRawId(item)), // key

--- a/mc/1.11.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.11.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -97,7 +97,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", ((BlockAccessor) block).getBlastResistance());
         blockDesc.addProperty("stackSize", Item.fromBlock(block).getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !defaultState.getMaterial().isFluid());
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registries.ITEMS.getRawId(item)), // key

--- a/mc/1.12.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.12.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -96,7 +96,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", ((BlockAccessor) block).getBlastResistance());
         blockDesc.addProperty("stackSize", Item.fromBlock(block).getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !defaultState.getMaterial().isFluid());
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registries.ITEMS.getRawId(item)), // key

--- a/mc/1.13/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.13/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -94,7 +94,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.getItem().getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !(block instanceof net.minecraft.class_3710));
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.14/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.14/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -8,6 +8,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -103,7 +104,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxAmount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.15/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.15/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -8,6 +8,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.MiningToolItem;
@@ -98,7 +99,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.16/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.16/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -8,6 +8,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -105,7 +106,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.17/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.17/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.18/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.18/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -147,7 +148,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         // }
         JsonArray dropsArray = new JsonArray();
         blockDesc.add("drops", dropsArray);
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
         blockDesc.addProperty("transparent", !defaultState.isOpaque());
         blockDesc.addProperty("filterLight", defaultState.getOpacity(EmptyBlockView.INSTANCE, BlockPos.ORIGIN));
         blockDesc.addProperty("emitLight", defaultState.getLuminance());

--- a/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -138,7 +139,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.10/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.11/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -138,7 +139,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.6/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.8/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -139,7 +140,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -138,7 +139,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.7/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -48,7 +48,7 @@ public class BlocksDataGenerator implements IDataGenerator {
 
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", ((BlockAccessor) block).getBlastResistance());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !block.getMaterial().isFluid());
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registries.ITEMS.getRawId(item)), // key

--- a/mc/1.8.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.8.9/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -97,7 +97,7 @@ public class BlocksDataGenerator implements IDataGenerator {
 
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", ((BlockAccessor) block).getBlastResistance());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !block.getMaterial().isFluid());
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registries.ITEMS.getRawId(item)), // key

--- a/mc/1.9.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.9.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -98,7 +98,7 @@ public class BlocksDataGenerator implements IDataGenerator {
 
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", ((BlockAccessor) block).getBlastResistance());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock) && !defaultState.getMaterial().isFluid());
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registries.ITEMS.getRawId(item)), // key

--- a/mc/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,7 @@ import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/26.1/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/26.1/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -16,6 +16,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.EmptyBlockGetter;
 import net.minecraft.world.level.block.AirBlock;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -135,7 +136,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.defaultDestroyTime());
         blockDesc.addProperty("resistance", block.getExplosionResistance());
         blockDesc.addProperty("stackSize", block.asItem().getDefaultMaxStackSize());
-        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.defaultDestroyTime() != -1.0f && !(block instanceof AirBlock) && !(block instanceof LiquidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key


### PR DESCRIPTION
Fixes water/lava being marked `diggable: true`.

## The bug
The `diggable` logic is `hardness != -1.0f && !(block instanceof AirBlock)`. Fluids have a hardness of **100** (not -1), so water and lava were incorrectly marked diggable in every version that has fluid blocks.

## The fix
Detect fluid blocks from the game code instead of hardcoding names — per @extremeheat's guidance on #79:

- **1.13+** (Yarn & Mojmap): `defaultState.getFluidState().isEmpty()` — a block is diggable only if its default state has no fluid.
- **1.7–1.12.2** (legacyYarn): `Material.isFluid()` — `!block.getMaterial().isFluid()` for 1.7/1.8.9, `!defaultState.getMaterial().isFluid()` for 1.9.4–1.12.2.

No block names are hardcoded; the check queries the actual Minecraft source.

## Verification
Every API was confirmed against the real mapping files for its era (Yarn v2 tiny mappings for 1.14/1.15/1.16/1.20, legacyYarn for 1.7–1.13, Mojmap for 1.21.5+):
- `BlockState.getFluidState()` (no-arg) exists from 1.13 onward (on `AbstractBlock.AbstractBlockState`, inherited by `BlockState`).
- `FluidState.isEmpty()` exists in all those versions.
- `Material.isFluid()` exists in all legacyYarn versions.

CI runs `runServer` for all 28 versions, which compiles and executes each generator, so any wrong API will fail the build.